### PR TITLE
Uses a passed sessionmaker instance in class

### DIFF
--- a/bottle_sqlalchemy.py
+++ b/bottle_sqlalchemy.py
@@ -47,7 +47,7 @@ Usage Example::
         db.add(entity)
 
 
-It is up to you create engine, and metadata, because SQLAlchemy has
+It is up to you create engine and metadata, because SQLAlchemy has
 a lot of options to do it. The plugin just handles the SQLAlchemy
 session.
 


### PR DESCRIPTION
SQLAlchemy advises not to make more than one call to 'sessionmaker()', you should use the same one for the entire app.

This uses a passed sessionmaker instance to create the session, so it should be more compliant.
