### PR TITLE
used install_requires on setup package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,7 @@ setup(
     py_modules = [
         'bottle_sqlalchemy'
     ],
-    requires = [
-        'bottle (>=0.9)',
-        'sqlalchemy'
-    ],
+    install_requires = ['bottle>=0.9', 'sqlalchemy'],
     classifiers = [
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Whenever the user is to use the package he will need the "sqlalchemy" and "bottle", I'm sending it install along with the "bottle-sqlalchemy" that do not have!